### PR TITLE
no more partials, just templates

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 Locator Handlebars Change History
 =================================
 
+@next (@date)
+------------------
+
+* no more partials, just templates. partials are just regular templates
+* adding hook to redefine the template name parser routine, in case you need more control to avoid naming conflicts
+
 0.1.0 (2013-06-27)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Handlebars template compiler for locator.
 
 This component is a result of the integration between [YUI][] and [Locator][] component from Yahoo! to compile [Handlebars][]' templates into [YUI][] Modules that could be used on the server thru express and on the client thru [YAF][].
 
-The beaufy of this is that you will NOT need to download the full `handlebars` parser component or the template itself, instead you use YUI Loader to load modules that will provision the handlebars templates in a form of javascript functions ready to be execute to produce a html fragment.
+The beauty of this is that you will NOT need to download the full `handlebars` parser component or the template itself, instead you use YUI Loader to load modules that will provision the handlebars templates in a form of javascript functions ready to be execute to produce a html fragment.
 
 [Handlebars]: http://handlebarsjs.com/
 [Locator]: https://github.com/yahoo/locator
@@ -59,17 +59,51 @@ On the client side, any [Handlebars][] template will be accessible as well thru 
 ```
 app.yui.use('<name-of-app>-templates-bar', function (Y) {
 
-    Y.Template._cache['<name-of-app>/bar']({
+    var html = Y.Template._cache['<name-of-app>/bar']({
         tagline: 'testing with some data for template bar'
-    }, Y.one('#container'));
+    });
 
 });
 ```
 
-In the example above, the `<name-of-app>` is the name specified in the `package.json` for your express application, and the template `bar.handlebars` will be rendered under the `#container` selector.
+In the example above, the `<name-of-app>` is the name specified in the `package.json` for your express application, and the template `bar.handlebars` will be rendered producing a HTML fragment.
 
 _note: in the near future, `Y.Template.render()` will be the formal API instead of using the `_cache` object, which is protected._
 
+
+Partials
+--------
+
+This component will support handlebars partials, but there are few caveats:
+
+* By default, any handlebars template under a folder called `partials` will be consider a partial.
+
+* The name of the folder to identify partials could be customized when you plug the plugin into locator.
+
+* Partials can be rendered as regular templates as well but the naming convention is slightly different.
+
+* Partials can be used in regular templates and within another partials as well, and `locator-handlebars` will provision them automatically thru YUI Loader.
+
+If you need to use a different folder name, you can customize it like this:
+
+```
+// using locator-handlebars yui plugin
+loc.plug(LocatorHandlebars.yui({
+    partialsDirname: 'my-partials'
+}));
+```
+
+Here is an example of a compiled partial:
+
+```
+app.yui.use('<name-of-app>-partials-foo', function (Y) {
+
+    var html = Y.Template._cache['<name-of-app>/foo']({
+        title: 'data to render the partial'
+    });
+
+});
+```
 
 TODO
 ----

--- a/README.md
+++ b/README.md
@@ -57,16 +57,16 @@ https://github.com/yahoo/locator-handlebars/tree/master/example
 On the client side, any [Handlebars][] template will be accessible as well thru `yui` as a regular yui module. Here is an example:
 
 ```
-app.yui.use('<name-of-app>-templates-bar', function (Y) {
+app.yui.use('<package-name>-templates-bar', function (Y) {
 
-    var html = Y.Template._cache['<name-of-app>/bar']({
+    var html = Y.Template._cache['<package-name>/bar']({
         tagline: 'testing with some data for template bar'
     });
 
 });
 ```
 
-In the example above, the `<name-of-app>` is the name specified in the `package.json` for your express application, and the template `bar.handlebars` will be rendered producing a HTML fragment.
+In the example above, the `<package-name>` is the package name specified in the `package.json` for the npm package that contains the template, which is usually the express application. `bar` comes from `bar.handlebars` where the filename is used as the name to register the template under `Y.Template`. By using the yui module name, you will be able to invoke the render action to produce a html fragment.
 
 _note: in the near future, `Y.Template.render()` will be the formal API instead of using the `_cache` object, which is protected._
 
@@ -74,36 +74,31 @@ _note: in the near future, `Y.Template.render()` will be the formal API instead 
 Partials
 --------
 
-This component will support handlebars partials, but there are few caveats:
+This component will support handlebars partials:
 
-* By default, any handlebars template under a folder called `partials` will be consider a partial.
+* A partial is just another template.
 
-* The name of the folder to identify partials could be customized when you plug the plugin into locator.
+* If a template uses another template (in a form of partial) it will be added to the dependency tree and will be loaded automatically.
 
-* Partials can be rendered as regular templates as well but the naming convention is slightly different.
+* The name used to register the template under `Y.Template` is based on the filename by default, but could be customized to avoid collisions.
 
-* Partials can be used in regular templates and within another partials as well, and `locator-handlebars` will provision them automatically thru YUI Loader.
-
-If you need to use a different folder name, you can customize it like this:
+If you want to use a different template name, you can write your own parser:
 
 ```
 // using locator-handlebars yui plugin
 loc.plug(LocatorHandlebars.yui({
-    partialsDirname: 'my-partials'
+    nameParser: function (source_path) {
+        var libpath = require('path'),
+            name = libpath.basename(source_path, libpath.extname(source_path));
+        if (source_path.indexOf('partials') > 0) {
+            name += '-partial';
+        }
+        return name;
+    }
 }));
 ```
 
-Here is an example of a compiled partial:
-
-```
-app.yui.use('<name-of-app>-partials-foo', function (Y) {
-
-    var html = Y.Template._cache['<name-of-app>/foo']({
-        title: 'data to render the partial'
-    });
-
-});
-```
+In the example above, when trying to parse `/path/to/foo.hbs` it will return `foo`, but when trying to `/path/to/partials/bar.hbs` it will return `foo-partial`, that will avoid collisions while giving you full control over the name resolution for the compiled templates.
 
 TODO
 ----

--- a/index.js
+++ b/index.js
@@ -1,7 +1,1 @@
-var plugin = require('./lib/plugin');
-
-module.exports = {
-    yui: function () {
-        return plugin;
-    }
-};
+module.exports = require('./lib/');

--- a/lib/core.js
+++ b/lib/core.js
@@ -14,11 +14,8 @@ var HB = require('yui/handlebars').Handlebars,
 
 module.exports = {
 
-    isPartial: function (source_path, partialDir) {
-        var dirname = libpath.dirname(source_path);
-
-        partialDir = libpath.normalize(partialDir);
-        return (dirname.indexOf(partialDir) === dirname.length - partialDir.length);
+    name: function (source_path) {
+        return libpath.basename(source_path, libpath.extname(source_path));
     },
 
     partials: function (source_path) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2013, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE.txt file for terms.
+ */
+
+/*jslint nomen:true, node:true */
+
+"use strict";
+
+var plugin = require('./plugin');
+
+/**
+Extends object with properties from other objects.
+
+    var a = { foo: 'bar' }
+      , b = { bar: 'baz' }
+      , c = { baz: 'xyz' };
+
+    utils.extends(a, b, c);
+    // a => { foo: 'bar', bar: 'baz', baz: 'xyz' }
+
+@method extend
+@param {Object} obj the receiver object to be extended
+@param {Object*} supplier objects
+@return {Object} The extended object
+**/
+function extend(obj) {
+    Array.prototype.slice.call(arguments, 1).forEach(function (source) {
+        var key;
+
+        if (!source) { return; }
+
+        for (key in source) {
+            if (source.hasOwnProperty(key)) {
+                obj[key] = source[key];
+            }
+        }
+    });
+    return obj;
+}
+
+module.exports = {
+    yui: function (config) {
+        config = extend({}, plugin.describe, config || {});
+        return extend({}, plugin, { describe: config });
+    }
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,8 +41,8 @@ function extend(obj) {
 }
 
 module.exports = {
-    yui: function (config) {
-        config = extend({}, plugin.describe, config || {});
-        return extend({}, plugin, { describe: config });
+    yui: function (describe) {
+        describe = extend({}, plugin.describe, describe || {});
+        return extend({}, plugin, { describe: describe });
     }
 };

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -8,15 +8,14 @@
 
 "use strict";
 
-var core = require('./core'),
-    libpath = require('path');
+var core = require('./core');
 
 module.exports = {
 
     describe: {
         summary: 'Compile handlebars templates to yui modules',
         extensions: ['hb', 'handlebars', 'hbs'],
-        partialsDirname: 'partials'
+        parseTemplateName: core.name
     },
 
     fileUpdated: function (evt, api) {
@@ -26,9 +25,8 @@ module.exports = {
             file = evt.file,
             source_path = file.fullPath,
             bundleName = file.bundleName,
-            treatItAsPartial = core.isPartial(source_path, this.describe.partialsDirname),
-            templateName = libpath.basename(file.relativePath, '.' + file.ext),
-            moduleName = bundleName + (treatItAsPartial ? '-partials-' : '-templates-') + templateName,
+            templateName = this.describe.parseTemplateName(source_path),
+            moduleName = bundleName + '-templates-' + templateName,
             destination_path = moduleName + '.js';
 
         return api.promise(function (fulfill, reject) {
@@ -45,7 +43,7 @@ module.exports = {
 
             // trying to write the destination file which will fulfill or reject the initial promise
             api.writeFileInBundle(bundleName, destination_path,
-                self._wrapAsYUI(bundleName, templateName, moduleName, treatItAsPartial, compiled, partials))
+                self._wrapAsYUI(bundleName, templateName, moduleName, compiled, partials))
                 .then(function () {
                     // provisioning the module to be used on the server side automatically
                     evt.bundle.useServerModules = evt.bundle.useServerModules || [];
@@ -58,7 +56,7 @@ module.exports = {
 
     },
 
-    _wrapAsYUI: function (bundleName, templateName, moduleName, isPartial, compiled, partials) {
+    _wrapAsYUI: function (bundleName, templateName, moduleName, compiled, partials) {
 
         // base dependency
         var dependencies = ["handlebars-base"];
@@ -69,7 +67,7 @@ module.exports = {
         partials = partials || [];
         partials.forEach(function (name) {
             // adding prefix to each partial
-            dependencies.push(bundleName + '-partials-' + name);
+            dependencies.push(bundleName + '-templates-' + name);
         });
 
         return [
@@ -79,12 +77,12 @@ module.exports = {
             '       partials = {};',
             '',
             '   Y.Array.each(' + JSON.stringify(partials) + ', function (name) {',
-            '       if (cache["' + bundleName + '/partials/' + '" + name]) {',
-            '           partials[name] = cache["' + bundleName + '/partials/' + '" + name];',
+            '       if (cache["' + bundleName + '/' + '" + name]) {',
+            '           partials[name] = cache["' + bundleName + '/' + '" + name];',
             '       }',
             '   });',
             '',
-            '   cache["' + bundleName + '/' + (isPartial ? 'partials/' : '') + templateName + '"] = function (data) {',
+            '   cache["' + bundleName + '/' + templateName + '"] = function (data) {',
             '       return fn(data, {',
             '           partials: partials',
             '       });',

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -16,7 +16,7 @@ module.exports = {
     describe: {
         summary: 'Compile handlebars templates to yui modules',
         extensions: ['hb', 'handlebars', 'hbs'],
-        partialDir: './partials'
+        partialsDirname: 'partials'
     },
 
     fileUpdated: function (evt, api) {
@@ -26,7 +26,7 @@ module.exports = {
             file = evt.file,
             source_path = file.fullPath,
             bundleName = file.bundleName,
-            treatItAsPartial = core.isPartial(source_path, this.describe.partialDir),
+            treatItAsPartial = core.isPartial(source_path, this.describe.partialsDirname),
             templateName = libpath.basename(file.relativePath, '.' + file.ext),
             moduleName = bundleName + (treatItAsPartial ? '-partials-' : '-templates-') + templateName,
             destination_path = moduleName + '.js';

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -15,7 +15,7 @@ module.exports = {
     describe: {
         summary: 'Compile handlebars templates to yui modules',
         extensions: ['hb', 'handlebars', 'hbs'],
-        parseTemplateName: core.name
+        nameParser: core.name
     },
 
     fileUpdated: function (evt, api) {
@@ -25,7 +25,7 @@ module.exports = {
             file = evt.file,
             source_path = file.fullPath,
             bundleName = file.bundleName,
-            templateName = this.describe.parseTemplateName(source_path),
+            templateName = this.describe.nameParser(source_path),
             moduleName = bundleName + '-templates-' + templateName,
             destination_path = moduleName + '.js';
 

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -21,8 +21,8 @@ describe('plugin', function () {
     describe('instance', function () {
 
         // we nee to write some tests here!
-        it('partialDir', function () {
-            expect(plugin.describe.partialDir).to.equal('./partials');
+        it('partialsDirname', function () {
+            expect(plugin.describe.partialsDirname).to.equal('partials');
         });
 
     });

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -21,8 +21,8 @@ describe('plugin', function () {
     describe('instance', function () {
 
         // we nee to write some tests here!
-        it('partialsDirname', function () {
-            expect(plugin.describe.partialsDirname).to.equal('partials');
+        it('summary', function () {
+            expect(plugin.describe.summary).to.equal('Compile handlebars templates to yui modules');
         });
 
     });


### PR DESCRIPTION
with this PR, we get:
- partials are just regular templates
- hook to redefine the template name parser routine, in case you need more control to avoid naming conflicts
