### PR TITLE
Use new `Y.Template.render` API in plugins

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -59,7 +59,7 @@ module.exports = {
     _wrapAsYUI: function (bundleName, templateName, moduleName, compiled, partials) {
 
         // base dependency
-        var dependencies = ["handlebars-base"];
+        var dependencies = ["template-base", "handlebars-base"];
 
         // each partial should be provisioned thru another yui module
         // and the name of the partial should translate into a yui module
@@ -73,20 +73,20 @@ module.exports = {
         return [
             'YUI.add("' + moduleName + '",function(Y, NAME){',
             '   var fn = Y.Template.Handlebars.revive(' + compiled + '),',
-            '       cache = Y.Template._cache = Y.Template._cache || {},',
             '       partials = {};',
             '',
             '   Y.Array.each(' + JSON.stringify(partials) + ', function (name) {',
-            '       if (cache["' + bundleName + '/' + '" + name]) {',
-            '           partials[name] = cache["' + bundleName + '/' + '" + name];',
+            '       var partial = Y.Template.get("' + bundleName + '/' +'" + name);',
+            '       if (partial) {',
+            '           partials[name] = partial;',
             '       }',
             '   });',
             '',
-            '   cache["' + bundleName + '/' + templateName + '"] = function (data) {',
+            '   Y.Template.register("' + bundleName + '/' + templateName + '", function (data) {',
             '       return fn(data, {',
             '           partials: partials',
             '       });',
-            '   };',
+            '   });',
             '}, "", {requires: ' + JSON.stringify(dependencies) + '});'
         ].join('\n');
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "author": "Caridy Patino <caridy@yahoo-inc.com> (http://github.com/caridy)",
     "contributors": [],
     "dependencies": {
-        "yui": "~3.11.0"
+        "yui": ">=3.12.0"
     },
     "main": "index",
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "locator-handlebars",
     "description": "Handlebars template compiler for locator",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "author": "Caridy Patino <caridy@yahoo-inc.com> (http://github.com/caridy)",
     "contributors": [],
     "dependencies": {


### PR DESCRIPTION
Now that `Y.Template.get` is part of the API, that solves the problem in #6.

This update lets `locator-handlebars` use the new `Y.Template.render` API by replacing `Y.Template._cache` with `Y.Template.register`.
