### PR TITLE
get example working again

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -5,11 +5,10 @@
 var express = require('express'),
     YUI = require('express-yui'),
     Locator = require('locator'),
-    LocatorHandlebars = require('../'),
+    LocatorHandlebars = require('locator-handlebars'),
     app = express();
 
 YUI.extend(app);
-YUI.debug();
 app.yui.setCoreFromAppOrigin();
 
 // custom view engine to rely on yui templates
@@ -43,7 +42,7 @@ new Locator({
 
         // listening for traffic only after locator finishes the walking process
         app.listen(3000, function () {
-            console.log("Server listening on port 3000");
+            console.log('Server listening on port 3000');
         });
 
     }, function (err) {

--- a/example/app.js
+++ b/example/app.js
@@ -5,10 +5,11 @@
 var express = require('express'),
     YUI = require('express-yui'),
     Locator = require('locator'),
-    LocatorHandlebars = require('locator-handlebars'),
+    LocatorHandlebars = require('../'),
     app = express();
 
-app.yui.debugMode();
+YUI.extend(app);
+YUI.debug();
 app.yui.setCoreFromAppOrigin();
 
 // custom view engine to rely on yui templates

--- a/example/package.json
+++ b/example/package.json
@@ -7,6 +7,7 @@
     "dependencies": {
         "express": "*",
         "express-yui": "*",
+        "locator-handlebars": "*",
         "locator": "*"
     }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -7,7 +7,8 @@
     "dependencies": {
         "express": "*",
         "express-yui": "*",
+        "locator": "*",
         "locator-handlebars": "*",
-        "locator": "*"
+        "yui": "~3.11.0"
     }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -4,11 +4,9 @@
     "version": "0.0.1",
     "private": true,
     "main": "app.js",
-    "devDependencies": {
+    "dependencies": {
         "express": "*",
         "express-yui": "*",
-        "locator": "*",
-        "locator-handlebars": "*",
-        "yui": "~3.11.0"
+        "locator": "*"
     }
 }


### PR DESCRIPTION
some minor updates to get the example/app.js working again
- ~~use parent directory for locator-handlebars~~
- ~~use expyui.debug() over deprecated app.yui.debugMode()~~ remove expyui.debug() 
- add missing .extend() after expyui api update
