### PR TITLE
relaxing yui dependency to support 3.x

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,10 @@
 Locator Handlebars Change History
 =================================
 
+0.2.3 (2013-09-16)
+
+* relaxing the yui dependency to support 3.x.
+
 0.2.2 (2013-09-12)
 
 * a handlebars instance may be passed to locator-handlebars in the "handlebars" property of it's options object, and it will be used for server-side compilation and rendering instead of YUI Handlebars.

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
     "name": "locator-handlebars",
     "description": "Handlebars template compiler for locator",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "author": "Caridy Patino <caridy@yahoo-inc.com> (http://github.com/caridy)",
     "contributors": [],
     "dependencies": {
-        "yui": "~3.11.0"
+        "yui": "3.x"
     },
     "main": "index",
     "keywords": [


### PR DESCRIPTION
the yui version installed at the app level should win, so users will have full control.
