### PR TITLE
Walk conditional branches for partials

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -41,9 +41,15 @@ PluginClass.prototype = {
                 program.statements.forEach(function (st) {
                     if (st.type === 'partial' && st.partialName.name) {
                         partials.push(st.partialName.name);
-                    } else if (st.program) {
-                        // collecting partials from sub programs
-                        walk(st.program);
+                    } else if (st.program || st.inverse) {
+                        if (st.program){
+                            // collecting partials from sub programs
+                            walk(st.program);
+                        }
+                        if (st.inverse){
+                            // collecting partials from sub programs in conditional branches
+                            walk(st.inverse);
+                        }
                     }
                 });
             }

--- a/tests/fixtures/testfile.handlebars
+++ b/tests/fixtures/testfile.handlebars
@@ -10,6 +10,8 @@
 
     {{#if people}}
 	    {{>abcd}}
+	{{else}}
+	    {{>efgh}}
 	{{/if}}
 </body>
 </html>

--- a/tests/lib/core.js
+++ b/tests/lib/core.js
@@ -25,6 +25,7 @@ describe('locator-handlebars', function () {
                 result = new Plugin().partialsParser(source);
             expect(result[0]).to.equal('baz');
             expect(result[1]).to.equal('abcd');
+            expect(result[2]).to.equal('efgh');
         });
 
         it('partialsdefault', function () {


### PR DESCRIPTION
I could be mistaken, but I think the `inverse` needs to be walked too so that the partial templates in `else` branches of conditional blocks get parsed.
