### PR TITLE
adding support for handlebars data so we could have intl global data passed around

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,11 @@ Locator Handlebars Change History
 @NEXT@
 ------------------
 
+0.3.2 (2014-01-30)
+------------------
+
+* PR #16: adding support for handblebars data to be propagated into the compiled function. This helps with the Intl integration.
+
 0.3.1 (2014-01-28)
 ------------------
 

--- a/lib/formats/yui.js
+++ b/lib/formats/yui.js
@@ -34,10 +34,10 @@ module.exports = function (bundleName, templateName, moduleName, precompiled, pa
         '       }',
         '   });',
         '',
-        '   Y.Template.register("' + bundleName + '/' + templateName + '", function (data) {',
-        '       return fn(data, {',
-        '           partials: partials',
-        '       });',
+        '   Y.Template.register("' + bundleName + '/' + templateName + '", function (obj, data) {',
+        '       data = data || {};',
+        '       data.partials = data.partials ? Y.merge(partials, data.partials) : partials;',
+        '       return fn(obj, data);',
         '   });',
         '}, "", {requires: ' + JSON.stringify(dependencies) + '});'
     ].join('\n');

--- a/lib/formats/yui.js
+++ b/lib/formats/yui.js
@@ -34,10 +34,10 @@ module.exports = function (bundleName, templateName, moduleName, precompiled, pa
         '       }',
         '   });',
         '',
-        '   Y.Template.register("' + bundleName + '/' + templateName + '", function (obj, data) {',
-        '       data = data || {};',
-        '       data.partials = data.partials ? Y.merge(partials, data.partials) : partials;',
-        '       return fn(obj, data);',
+        '   Y.Template.register("' + bundleName + '/' + templateName + '", function (data, options) {',
+        '       options = options || {};',
+        '       options.partials = options.partials ? Y.merge(partials, options.partials) : partials;',
+        '       return fn(data, options);',
         '   });',
         '}, "", {requires: ' + JSON.stringify(dependencies) + '});'
     ].join('\n');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "locator-handlebars",
     "description": "Handlebars template compiler for locator",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "author": "Caridy Patino <caridy@yahoo-inc.com> (http://github.com/caridy)",
     "contributors": [],
     "dependencies": {


### PR DESCRIPTION
With this PR, handlebars templates compiled thru LocatorHandlebars will support a 2nd argument when called, this argument can have a `partails`, `data` and `helpers` that will be used while executing the template. Specifically, the data member can be accessed by any helpers independent of the context and the hash.

This helps with the Intl support, e.g.:

```
var tmp = Y.Template.get('foo');
tmp({ val: 1, val2: 2 }, { 
  data: {
     intl: {
          locales: ['en-US'],
          messages: {
              NAME: 'nombre'
          }
     }
  }
});
```
