### PR TITLE
Feature/js mustache

### DIFF
--- a/lib/formats/esm.js
+++ b/lib/formats/esm.js
@@ -1,0 +1,46 @@
+/*jslint nomen:true, node:true */
+
+"use strict";
+
+module.exports = function (bundleName, templateName, moduleName, precompiled, partials, prefix) {
+
+    // base dependency
+    var dependencies = ["template-base", "handlebars-base"];
+
+    // each partial should be provisioned thru another yui module
+    // and the name of the partial should translate into a yui module
+    // to become a dependency
+    partials = partials || [];
+    // transform paths to custom naming convention
+    partials = partials.map(function (name) {
+        return name.replace(/\//g, '-');
+    });
+    partials.forEach(function (name) {
+        // adding prefix to each partial
+        dependencies.push((prefix || bundleName + '-tmpl-') + name);
+    });
+    var imports = dependencies.map(function (dep) {
+        return "import '" + dep + "';";
+    });
+    return [
+        '// @module ' + moduleName + '',
+    ].concat(imports).concat([
+        'import Y from \'yui-instance\';',
+        'var fn = Y.Template.Handlebars.revive(' + precompiled + '),',
+        '    partials = {};',
+        '',
+        'Y.Array.each(' + JSON.stringify(partials) + ', function (name) {',
+        '    var fn = Y.Template.get("' + bundleName + '/" + name);',
+        '    if (fn) {',
+        '        partials[name] = fn;',
+        '    }',
+        '});',
+        '',
+        'Y.Template.register("' + bundleName + '/' + templateName + '", function (data, options) {',
+        '    options = options || {};',
+        '    options.partials = options.partials ? Y.merge(partials, options.partials) : partials;',
+        '    return fn(data, options);',
+        '});'
+    ]).join('\n');
+
+};

--- a/lib/formats/yui.js
+++ b/lib/formats/yui.js
@@ -8,7 +8,7 @@
 
 "use strict";
 
-module.exports = function (bundleName, templateName, moduleName, precompiled, partials) {
+module.exports = function (bundleName, templateName, moduleName, precompiled, partials, prefix) {
 
     // base dependency
     var dependencies = ["template-base", "handlebars-base"];
@@ -19,7 +19,7 @@ module.exports = function (bundleName, templateName, moduleName, precompiled, pa
     partials = partials || [];
     partials.forEach(function (name) {
         // adding prefix to each partial
-        dependencies.push(bundleName + '-template-' + name);
+        dependencies.push((prefix || bundleName + '-tmpl-') + name);
     });
 
     return [

--- a/lib/formats/yui.js
+++ b/lib/formats/yui.js
@@ -17,13 +17,17 @@ module.exports = function (bundleName, templateName, moduleName, precompiled, pa
     // and the name of the partial should translate into a yui module
     // to become a dependency
     partials = partials || [];
+    // transform paths to custom naming convention
+    partials = partials.map(function (name) {
+        return name.replace(/\//g, '-');
+    });
     partials.forEach(function (name) {
         // adding prefix to each partial
         dependencies.push((prefix || bundleName + '-tmpl-') + name);
     });
 
     return [
-        'YUI.add("' + moduleName + '",function(Y, NAME){',
+        'YUI.add("' + moduleName + '",function(Y, NAME) {',
         '   var fn = Y.Template.Handlebars.revive(' + precompiled + '),',
         '       partials = {};',
         '',

--- a/lib/formats/yui.js
+++ b/lib/formats/yui.js
@@ -1,9 +1,3 @@
-/*
- * Copyright (c) 2013, Yahoo! Inc.  All rights reserved.
- * Copyrights licensed under the New BSD License.
- * See the accompanying LICENSE.txt file for terms.
- */
-
 /*jslint nomen:true, node:true */
 
 "use strict";
@@ -11,19 +5,22 @@
 module.exports = function (bundleName, templateName, moduleName, precompiled, partials, prefix) {
 
     // base dependency
-    var dependencies = ["template-base", "handlebars-base"];
+    var dependencies = ["template-base", "handlebars-base"],
+        // Used to store both the original file path and the dashed name
+        partialModuleToPathMap = {};
 
     // each partial should be provisioned thru another yui module
     // and the name of the partial should translate into a yui module
     // to become a dependency
     partials = partials || [];
-    // transform paths to custom naming convention
-    partials = partials.map(function (name) {
-        return name.replace(/\//g, '-');
-    });
-    partials.forEach(function (name) {
-        // adding prefix to each partial
-        dependencies.push((prefix || bundleName + '-tmpl-') + name);
+    partials.map(function (filePath) {
+        // transform paths to custom naming convention
+        var moduleSuffix = filePath.replace(/\//g, '-');
+        // map dashed module suffix to original file name
+        // Ex: { "path-to-mustache-file" : "path/to/mustache/file" }
+        partialModuleToPathMap[moduleSuffix] = filePath;
+        // add dependency
+        dependencies.push((prefix || bundleName + '-tmpl-') + moduleSuffix);
     });
 
     return [
@@ -31,10 +28,11 @@ module.exports = function (bundleName, templateName, moduleName, precompiled, pa
         '   var fn = Y.Template.Handlebars.revive(' + precompiled + '),',
         '       partials = {};',
         '',
-        '   Y.Array.each(' + JSON.stringify(partials) + ', function (name) {',
-        '       var fn = Y.Template.get("' + bundleName + '/" + name);',
+        '   Y.Object.each(' + JSON.stringify(partialModuleToPathMap) + ', function (filePath, moduleSuffix) {',
+        '       var fn = Y.Template.get("' + bundleName + '/" + moduleSuffix);',
         '       if (fn) {',
-        '           partials[name] = fn;',
+        '           partials[filePath] = fn;',
+        '           partials[moduleSuffix] = fn;',
         '       }',
         '   });',
         '',

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -68,7 +68,7 @@ PluginClass.prototype = {
             file = evt.file,
             source_path = file.fullPath,
             bundleName = file.bundleName,
-            prefix = this.describe.options.prefix || (bundleName + '-template-'),
+            prefix = this.describe.options.prefix || (bundleName + '-tmpl-'),
             templateName = this.nameParser(source_path),
             moduleName = prefix + templateName,
             destination_path = moduleName + '.js',
@@ -103,7 +103,7 @@ PluginClass.prototype = {
             if (format) {
                 // trying to write the destination file which will fulfill or reject the initial promise
                 api.writeFileInBundle(bundleName, destination_path,
-                    require('./formats/' + format)(bundleName, templateName, moduleName, precompiled, partials))
+                    require('./formats/' + format)(bundleName, templateName, moduleName, precompiled, partials, prefix))
                     .then(fulfill, reject);
             } else {
                 fulfill();

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -81,7 +81,7 @@ PluginClass.prototype = {
                 partials;
 
             try {
-                partials = self.partialsParser(source);
+                partials = self.describe.options.parsePartials ? self.partialsParser(source) : [];
                 precompiled = handlebars.precompile(source, options);
                 compiled = handlebars.compile(source, options);
             } catch (e) {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -68,11 +68,11 @@ PluginClass.prototype = {
             file = evt.file,
             source_path = file.fullPath,
             bundleName = file.bundleName,
+            prefix = this.describe.options.prefix || (bundleName + '-template-'),
             templateName = this.nameParser(source_path),
-            moduleName = bundleName + '-template-' + templateName,
+            moduleName = prefix + templateName,
             destination_path = moduleName + '.js',
             format = this.describe.options.format;
-
         return api.promise(function (fulfill, reject) {
 
             var source = libfs.readFileSync(source_path, 'utf8'),

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "locator-handlebars",
+    "name": "zlocator-handlebars",
     "description": "Handlebars template compiler for locator",
     "version": "0.3.2",
     "author": "Caridy Patino <caridy@yahoo-inc.com> (http://github.com/caridy)",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "zlocator-handlebars",
+    "name": "locator-handlebars",
     "description": "Handlebars template compiler for locator",
     "version": "0.3.2",
     "author": "Caridy Patino <caridy@yahoo-inc.com> (http://github.com/caridy)",

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -56,6 +56,45 @@ describe('locator-handlebars', function () {
             }, next);
         });
 
+        it('esm format', function (next) {
+            var file = { bundleName: 'testing' },
+                bundle = { name: 'testing' },
+                evt = { file: file, bundle: bundle },
+                api = {},
+                filecall = 0;
+            file.fullPath = libpath.join(__dirname, '../fixtures/testfile.handlebars');
+            api.promise = function (fn) {
+                return new libpromise.Promise(fn);
+            };
+            file.fullPath = libpath.join(__dirname, '../fixtures/testfile.handlebars');
+            api.writeFileInBundle =  function (bundleName, relativePath, contents, options) {
+                filecall += 1;
+                expect(bundleName).to.equal("testing");
+                expect(relativePath).to.equal("testing-tmpl-testfile.js");
+                expect(contents.substring(0, 195)).to.equal([
+                    "// @module testing-tmpl-testfile",
+                    "import 'template-base';",
+                    "import 'handlebars-base';",
+                    "import 'testing-tmpl-baz';",
+                    "import 'testing-tmpl-abcd';",
+                    "import 'testing-tmpl-efgh';",
+                    "import Y from 'yui-instance';"
+                ].join('\n'));
+                return new libpromise.Promise(function (fulfill, reject) {
+                    fulfill();
+                });
+            };
+            new Plugin({ format: 'esm', parsePartials: true }).fileUpdated(evt, api).then(function () {
+                try {
+                    expect(1).to.equal(filecall);
+                    expect(evt.bundle.template['testfile']).to.be.a('function');
+                    next();
+                } catch (err) {
+                    next(err);
+                }
+            }, next);
+        });
+
         it('fileUpdated if file is an invalid template', function () {
             var file = { bundleName: 'testing', relativePath: '../fixtures/invalid.handlebars' },
                 bundle = { name: 'testing' },

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -39,13 +39,13 @@ describe('locator-handlebars', function () {
             api.writeFileInBundle =  function (bundleName, relativePath, contents, options) {
                 filecall += 1;
                 expect(bundleName).to.equal("testing");
-                expect(relativePath).to.equal("testing-template-testfile.js");
-                expect(contents.substring(0, 53)).to.equal("YUI.add(\"testing-template-testfile\",function(Y, NAME)");
+                expect(relativePath).to.equal("testing-tmpl-testfile.js");
+                expect(contents.substring(0, 51)).to.equal("YUI.add(\"testing-tmpl-testfile\",function(Y, NAME) {");
                 return new libpromise.Promise(function (fulfill, reject) {
                     fulfill();
                 });
             };
-            new Plugin({ format: 'yui' }).fileUpdated(evt, api).then(function () {
+            new Plugin({ format: 'yui', parsePartials: true }).fileUpdated(evt, api).then(function () {
                 try {
                     expect(1).to.equal(filecall);
                     expect(evt.bundle.template['testfile']).to.be.a('function');


### PR DESCRIPTION
Relavent ticket: PPL-8502

 Now a module can reference a partial in 3 ways
- path-to-module
  - path/to/module  (this is new)
  - Custom partial mapping at registration

Things still left to do:
- Doing the same for esm.js (I want to do this first before rolling it out to everywhere)
- Unit tests
